### PR TITLE
Handle unsupported

### DIFF
--- a/block.go
+++ b/block.go
@@ -118,6 +118,20 @@ type Block interface {
 	GetType() BlockType
 }
 
+type UnsupportedBlock struct {
+	Object         ObjectType             `json:"object"`
+	ID             BlockID                `json:"id,omitempty"`
+	Type           BlockType              `json:"type"`
+	CreatedTime    *time.Time             `json:"created_time,omitempty"`
+	LastEditedTime *time.Time             `json:"last_edited_time,omitempty"`
+	HasChildren    bool                   `json:"has_children,omitempty"`
+	RawData        map[string]interface{} `json:"-"`
+}
+
+func (b UnsupportedBlock) GetType() BlockType {
+	return b.Type
+}
+
 type ParagraphBlock struct {
 	Object         ObjectType `json:"object"`
 	ID             BlockID    `json:"id,omitempty"`
@@ -448,8 +462,12 @@ func decodeBlock(raw map[string]interface{}) (Block, error) {
 		b = &PdfBlock{}
 	case BlockTypeBookmark:
 		b = &BookmarkBlock{}
+	case BlockTypeUnsupported:
+		b = &UnsupportedBlock{}
 	default:
-		return nil, fmt.Errorf("unsupported block type: %s", raw["type"].(string))
+		b = &UnsupportedBlock{
+			RawData: raw,
+		}
 	}
 	j, err := json.Marshal(raw)
 	if err != nil {

--- a/block.go
+++ b/block.go
@@ -430,6 +430,8 @@ func decodeBlock(raw map[string]interface{}) (Block, error) {
 		b = &NumberedListItemBlock{}
 	case BlockTypeToDo:
 		b = &ToDoBlock{}
+	case BlockTypeCode:
+		b = &CodeBlock{}
 	case BlockTypeToggle:
 		b = &ToggleBlock{}
 	case BlockTypeChildPage:

--- a/block.go
+++ b/block.go
@@ -313,6 +313,24 @@ type Image struct {
 	External *FileObject `json:"external,omitempty"`
 }
 
+type CodeBlock struct {
+	Object         ObjectType `json:"object"`
+	ID             BlockID    `json:"id,omitempty"`
+	Type           BlockType  `json:"type"`
+	CreatedTime    *time.Time `json:"created_time,omitempty"`
+	LastEditedTime *time.Time `json:"last_edited_time,omitempty"`
+	Code           Code       `json:"code"`
+}
+
+func (b CodeBlock) GetType() BlockType {
+	return b.Type
+}
+
+type Code struct {
+	Text     []RichText `json:"text"`
+	Language string     `json:"language"`
+}
+
 type VideoBlock struct {
 	Object         ObjectType `json:"object"`
 	ID             BlockID    `json:"id,omitempty"`

--- a/const.go
+++ b/const.go
@@ -193,6 +193,7 @@ const (
 	BlockTypeFile        BlockType = "file"
 	BlockTypePdf         BlockType = "pdf"
 	BlockTypeBookmark    BlockType = "bookmark"
+	BlockTypeCode        BlockType = "code"
 	BlockTypeUnsupported BlockType = "unsupported"
 )
 


### PR DESCRIPTION
Add `UnsupportedBlock` to avoid stopping getting children when an unsupported block is retrieved.